### PR TITLE
Am update to dry struct 1 0

### DIFF
--- a/lib/pub_sub/dry.rb
+++ b/lib/pub_sub/dry.rb
@@ -1,5 +1,5 @@
 require 'dry-struct'
 
 module Types
-  include Dry::Types.module
+  include Dry.Types()
 end

--- a/lib/pub_sub/event_emission.rb
+++ b/lib/pub_sub/event_emission.rb
@@ -27,7 +27,7 @@ module PubSub
       event_payload_attribute_names.each_with_object({}) do |attribute_name, result|
         result[attribute_name] = PayloadAttribute.new(attribute_name, explicit_payload, context).get
       rescue PayloadAttribute::CannotEvaluate => cannot_evaluate_error
-        if event_class.schema[attribute_name.to_sym].default?
+        if event_class.schema.key(attribute_name).default?
           next
         else
           raise(

--- a/lib/pub_sub/version.rb
+++ b/lib/pub_sub/version.rb
@@ -1,3 +1,3 @@
 module PubSub
-  VERSION = '0.0.6'
+  VERSION = '0.0.7'
 end


### PR DESCRIPTION
For `dry-struct` version 1.0 we need `dry-types` with version 1.2. In this version `schema` is not longer hash. 